### PR TITLE
Add GH action for deploying to GH pages

### DIFF
--- a/template/.github/workflows/gh-pages.yml
+++ b/template/.github/workflows/gh-pages.yml
@@ -1,0 +1,27 @@
+name: github pages
+
+on:
+    push:
+        branches:
+            - master
+
+jobs:
+    deploy:
+        runs-on: ubuntu-18.04
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  submodules: false
+                  fetch-depth: 1
+
+            - name: Install
+              run: npm install
+
+            - name: Build
+              run: npm run build
+
+            - name: Deploy
+              uses: peaceiris/actions-gh-pages@v3
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  publish_dir: ./build

--- a/template/package.json
+++ b/template/package.json
@@ -60,6 +60,7 @@
 			"prettier"
 		]
 	},
+	"homepage": ".",
 	"husky": {
 		"hooks": {
 			"pre-commit": "lint-staged"


### PR DESCRIPTION
This change makes every new CRA project with this template include the GitHub actions configuration for deploying `npm run build` to the `gh-pages` branch. The only thing left to do is go to the repository settings and _enable_ GH pages there.

Added the `homepage` property to `package.json` so that files are referenced correctly. As a drawback, some React router may be confused by it.

Feel free to reject this PR if you want, I'm not sure if this is the direction you want to take this template into in the first place :)